### PR TITLE
chore: add SonarQube scan workflow

### DIFF
--- a/.github/workflows/sonarqube-monorepo-scan.yml
+++ b/.github/workflows/sonarqube-monorepo-scan.yml
@@ -1,0 +1,25 @@
+name: SonarQube Scan
+
+on:
+  schedule:
+    - cron: '15 3,15 * * *'
+  workflow_dispatch:
+
+jobs:
+  sonar-scan:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v7.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarqube.mapup.ai
+        with:
+          args: >
+            -Dsonar.projectKey=tollguru-tolltally-api-payload-examples


### PR DESCRIPTION
This automated PR adds a SonarQube scan workflow (`.github/workflows/sonarqube-monorepo-scan.yml`) to scan the codebase.

### Repository Structure
- **Type**: Single Project
- **Detected Projects**: 1

### Manually Created SonarQube Projects Required
Please ensure the following project key(s) are created in SonarQube under the server:
- **Project Name**: root
  - **Path**: `.`
  - **SonarQube Project Key**: `tollguru-tolltally-api-payload-examples`

---
*Created automatically by the SonarQube Workflow Bot.*