### PR TITLE
chore: add SonarQube scan workflow

### DIFF
--- a/.github/workflows/sonarqube-monorepo-scan.yml
+++ b/.github/workflows/sonarqube-monorepo-scan.yml
@@ -1,0 +1,47 @@
+name: SonarQube Scan
+
+on:
+  schedule:
+    - cron: '15 3,15 * * *'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual run'
+        required: false
+        default: 'Manual SonarQube scan'
+
+concurrency:
+  group: sonar-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  SONAR_HOST_URL: https://sonarqube.mapup.ai
+
+jobs:
+  sonarqube-scan:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log manual run reason
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "Manual trigger - ${{ github.event.inputs.reason }}"
+
+      - name: SonarQube scan
+        uses: SonarSource/sonarqube-scan-action@v7.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectKey=tollguru-tolltally-api-payload-examples
+            -Dsonar.sources=.
+            -Dsonar.exclusions=**/node_modules/**,**/.next/**,**/.astro/**,**/dist/**,**/build/**,**/coverage/**,**/_static/**,**/.vercel/**,**/*.min.js,**/patches/**,**/ThirdPartyLicenses/**


### PR DESCRIPTION
This automated PR adds a SonarQube scan workflow (`.github/workflows/sonarqube-monorepo-scan.yml`) to scan the codebase.

### Repository Structure
- **Type**: Single Project
- **Detected Projects**: 1

### Manually Created SonarQube Projects Required
Please ensure the following project key(s) are created in SonarQube under the server:
- **Project Name**: root
  - **Path**: `.`
  - **SonarQube Project Key**: `tollguru-tolltally-api-payload-examples`

---
*Created automatically by the SonarQube Workflow Bot.*